### PR TITLE
refactor: standardize time zone handling in layout and request config…

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -41,7 +41,8 @@ export default async function RootLayout(props: {
 
   setRequestLocale(locale as Locale);
 
-  const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
+  const resolvedTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timeZone = resolvedTimeZone || 'Europe/Tallinn';
 
   const nonce = (await headers()).get('x-nonce') ?? ' ';
 

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -11,6 +11,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
   return {
     locale,
+    timeZone: 'Europe/Tallinn',
     messages: (await import(`../messages/${locale}.json`)).default,
   };
 });


### PR DESCRIPTION
This pull request introduces updates to the handling of time zones within the application's locale configuration. The main changes ensure that a default time zone is consistently set to 'Europe/Tallinn' when one cannot be resolved, improving reliability in internationalization and date/time formatting.

**Time zone handling improvements:**

* In `app/[locale]/layout.tsx`, the time zone is now explicitly set to 'Europe/Tallinn' if it cannot be resolved from the user's environment, preventing potential issues with undefined time zones. ([app/[locale]/layout.tsxL44-R45](diffhunk://#diff-44ca66e460fac15e804a2ab56f6038ef2dd0a231881294f0a3895f9ad7624c58L44-R45))
* In `i18n/request.ts`, the returned configuration now always includes a `timeZone` property set to 'Europe/Tallinn', ensuring a consistent default across requests.…uration