### PR TITLE
refactor: enhance getEquipmentMinPricesByPayment to sort results by payment type

### DIFF
--- a/app/utils/packagesHelper.ts
+++ b/app/utils/packagesHelper.ts
@@ -88,6 +88,7 @@ export const groupEquipmentByCombination = (
  * @returns Object mapping each payment type to the minimum price found
  */
 export const getEquipmentMinPricesByPayment = (equipment: EquipmentItem[]) => {
+  const paymentOrder = ['rent', 'installments', 'full_purchase'];
   const result: Record<string, number> = {};
 
   for (const item of equipment) {
@@ -99,5 +100,12 @@ export const getEquipmentMinPricesByPayment = (equipment: EquipmentItem[]) => {
     }
   }
 
-  return result;
+  const sortedResult: Record<string, number> = {};
+  for (const paymentType of paymentOrder) {
+    if (result[paymentType] !== undefined) {
+      sortedResult[paymentType] = result[paymentType];
+    }
+  }
+
+  return sortedResult;
 };


### PR DESCRIPTION
This pull request updates the logic in the `getEquipmentMinPricesByPayment` function to ensure that the returned object lists payment types in a consistent order. This change helps standardize the output and may be important for downstream consumers that rely on a specific order.

Improvements to output consistency:

* Added a `paymentOrder` array to define the desired order of payment types and modified the function to return results sorted according to this order, rather than the default object key order. [[1]](diffhunk://#diff-d9063f3ae9cc59e42159ea501d434a227f8cfe0260cab780642330314b9fdf63R91) [[2]](diffhunk://#diff-d9063f3ae9cc59e42159ea501d434a227f8cfe0260cab780642330314b9fdf63L102-R110)…ayment type