### PR TITLE
refactor: standardize key naming for full purchase minimum price in localization files

### DIFF
--- a/messages/et.json
+++ b/messages/et.json
@@ -136,7 +136,7 @@
         "label": "Seadmed",
         "rentMinPrice": "Seadme rent alates {rent_fee} € / kuus",
         "installmentsMinPrice": "Seadme järelmaks alates {installments_fee} € / kuus",
-        "fullPurchaseMinPrice": "Seadme väljaost alates {full_purchase_fee} €",
+        "full_purchaseMinPrice": "Seadme väljaost alates {full_purchase_fee} €",
         "allCombinations": "Teenuse kasutamiseks on vajalik seadmed. Allpool on esitatud kõik võimalikud seadmekomplektid.",
         "noEquipment": "Sobivaid seadmeid ei leidu."
       },

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -136,7 +136,7 @@
         "label": "Оборудование",
         "rentMinPrice": "Аренда устройства от {rent_fee} € / мес",
         "installmentsMinPrice": "Рассрочка устройства от {installments_fee} € / мес",
-        "fullPurchaseMinPrice": "Покупка устройства от {full_purchase_fee} €",
+        "full_purchaseMinPrice": "Покупка устройства от {full_purchase_fee} €",
         "allCombinations": "Для использования услуги требуется оборудование. Ниже представлены все возможные комплектации устройств.",
         "noEquipment": "Нет доступных устройств."
       },


### PR DESCRIPTION
This pull request makes a minor update to localization keys in the Estonian and Russian translation files to ensure consistency in naming conventions.

* Renamed the key `fullPurchaseMinPrice` to `full_purchaseMinPrice` in both `messages/et.json` and `messages/ru.json` to standardize key formatting. [[1]](diffhunk://#diff-f94596badefd87424c3a0205e05ffaf2822370fd372852c4d7d45cc6c2b79ac4L139-R139) [[2]](diffhunk://#diff-5e75b39fcc008a0e8044f12470210a976838de980c8671485ce301d0a5ac0a77L139-R139)…ocalization files