### PR TITLE
refactor: simplify tooltip content handling in EquipmentHeader component

### DIFF
--- a/app/components/ui/packages/modal/details/PackageEquipmentSection.tsx
+++ b/app/components/ui/packages/modal/details/PackageEquipmentSection.tsx
@@ -53,19 +53,19 @@ export default function PackageEquipmentSection({
         device.description)
       : '';
 
-    const tooltipContent = device.model
-      ? `${device.model}${translatedDescription ? ` - ${translatedDescription}` : ''}`
-      : translatedDescription;
+    const tooltipContent = translatedDescription || device.model || '';
 
-    return device.model || device.description ? (
+    if (!tooltipContent) {
+      return <p>{deviceType}</p>;
+    }
+
+    return (
       <Tooltip
         elementToInteract={
           <p className="text-primary underline">{deviceType}</p>
         }
         content={tooltipContent}
       />
-    ) : (
-      <p>{deviceType}</p>
     );
   }
 


### PR DESCRIPTION
This pull request updates the tooltip logic in the `PackageEquipmentSection` component to improve how device information is displayed. The main change is that the tooltip will now only appear if there is a description or model available, and the tooltip content prioritizes the description over the model.

**Tooltip logic improvements:**

* Changed the tooltip content to use the translated description if available, otherwise fallback to the device model, or display nothing if neither exists.
* Updated the rendering logic so that the tooltip is only shown when there is content to display; otherwise, only the device type is rendered without a tooltip.