### PR TITLE
refactor: implement rate limiting and origin validation in email sending route

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -4,7 +4,61 @@ import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+const ALLOWED_ORIGINS = [
+  'https://netihind.ee',
+  'https://test.netihind.ee',
+  'https://www.netihind.ee',
+  'https://www.test.netihind.ee',
+  'http://localhost:3000',
+];
+
+const rateLimit = new Map<string, number[]>();
+const MAX_REQUESTS = 3;
+const TIME_WINDOW = 60 * 1000;
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const requests = rateLimit.get(ip) || [];
+
+  const recentRequests = requests.filter((time) => now - time < TIME_WINDOW);
+
+  if (recentRequests.length >= MAX_REQUESTS) {
+    return false;
+  }
+
+  recentRequests.push(now);
+  rateLimit.set(ip, recentRequests);
+
+  if (rateLimit.size > 1000) {
+    const oldestEntries = Array.from(rateLimit.entries())
+      .sort(([, a], [, b]) => Math.max(...b) - Math.max(...a))
+      .slice(500);
+    rateLimit.clear();
+    oldestEntries.forEach(([key, value]) => rateLimit.set(key, value));
+  }
+
+  return true;
+}
+
 export async function POST(req: NextRequest) {
+  // Проверяем origin
+  const origin = req.headers.get('origin');
+  if (origin && !ALLOWED_ORIGINS.includes(origin)) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0] ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+
+  if (!checkRateLimit(ip)) {
+    return Response.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 },
+    );
+  }
+
   const body = await req.json();
   const { type, ...values } = body;
   try {


### PR DESCRIPTION
This pull request adds security and abuse prevention mechanisms to the `app/api/send/route.ts` API endpoint. The most important changes are the introduction of origin validation and rate limiting, which help protect the endpoint from unauthorized use and excessive requests.

Security enhancements:

* Added validation of request origin against a whitelist (`ALLOWED_ORIGINS`) to block requests from unauthorized domains.

Abuse prevention:

* Implemented a rate limiting system using an in-memory map to restrict each IP to a maximum of 3 requests per minute, returning a 429 error if exceeded.
* Added logic to manage the size of the rate limit map, periodically pruning older entries to prevent memory issues.

Request handling improvements:

* Extracted the user's IP address from request headers (`x-forwarded-for`, `x-real-ip`) to use for rate limiting.